### PR TITLE
Basic changes to be runnable on 1.9.2

### DIFF
--- a/playbooks/roles/bootnode/templates/node.toml.j2
+++ b/playbooks/roles/bootnode/templates/node.toml.j2
@@ -18,7 +18,7 @@ allow_ips = "public"
 [rpc]
 #apis = ["web3", "eth", "parity", "parity_set", "net", "traces", "rpc"]
 apis = ["web3","eth","net"]
-threads = 4
+processing_threads = 4
 
 {% if bootnode_archive|default("off") == "on" %}
 [ui]
@@ -36,8 +36,6 @@ pruning = "archive"
 pruning_history = 1200
 fat_db = "on"
 cache_size_db = 12000
-min_peers = 5
-max_peers = 10
 {% endif %}
 
 [misc]

--- a/playbooks/roles/poa-parity/tasks/main.yml
+++ b/playbooks/roles/poa-parity/tasks/main.yml
@@ -16,7 +16,7 @@
     group: "{{ username }}"
 
 - name: Download parity-bin
-  get_url: url="{{ PARITY_BIN_LOC }}" dest={{ home }}/parity mode=0755
+  get_url: url="{{ PARITY_BIN_LOC }}" dest={{ home }}/parity mode=0755 checksum="sha256:{{ PARITY_BIN_SHA256 }}"
   notify:
     - restart poa-parity
 

--- a/terraform/azure/templates/group_vars.tpl
+++ b/terraform/azure/templates/group_vars.tpl
@@ -19,7 +19,8 @@ ntpservers:
 
 NODE_PWD: "node.pwd" # don't change this one
 NODE_SOURCE_DEB: "https://deb.nodesource.com/node_8.x"
-PARITY_BIN_LOC: "https://github.com/poanetwork/binary-releases/releases/download/1.8.4/parity"
+PARITY_BIN_LOC: "https://d1h4xl4cr1h0mo.cloudfront.net/v1.9.2/x86_64-unknown-linux-gnu/parity"
+PARITY_BIN_SHA256: "3604a030388cd2c22ebe687787413522106c697610426e09b3c5da4fe70bbd33"
 
 SCRIPTS_MOC_BRANCH: "sokol"
 SCRIPTS_VALIDATOR_BRANCH: "sokol"


### PR DESCRIPTION
Minimal changes requires to be run on latest parity 1.9.2