### PR TITLE
Add a check for initial keys before converting them

### DIFF
--- a/helper-scripts/gen-prod-keys/KeysManager.abi.json
+++ b/helper-scripts/gen-prod-keys/KeysManager.abi.json
@@ -20,5 +20,24 @@
     "payable": false,
     "stateMutability": "nonpayable",
     "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_initialKey",
+        "type": "address"
+      }
+    ],
+    "name": "getInitialKey",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
   }
 ]


### PR DESCRIPTION
Check initial key state before converting it to production keys.
If key is already deactivated - skip it.
If key is invalid - throw exception.
