### PR TITLE
Comments added, to allow generate jinja template from toml

### DIFF
--- a/helper-scripts/network-tests/config-sample.toml
+++ b/helper-scripts/network-tests/config-sample.toml
@@ -1,8 +1,10 @@
 #  settings
+# mandatory
 url = "..url"
 keyStorePath = "path/...moc.json"
 passwordFrom = "password"
 addressTo = "0x.."
+# defaults
 maxRounds = 3
 gasPrice = "1000000000"
 simpleTransactionGas = "21000"


### PR DESCRIPTION
Externall tool will generate jinja config for ansible from toml config from repo. Comments are necessary for that script to work. PR is povided earlier then tool because:
1) It breaks nothing
2) It will be helpfull in testing process