### PR TITLE
Use branch with previous version of governance

### DIFF
--- a/azure/roles/moc-preconf/defaults/main.yml
+++ b/azure/roles/moc-preconf/defaults/main.yml
@@ -2,7 +2,7 @@
 DEPLOYMENT_PLAYBOOKS: https://github.com/poanetwork/deployment-playbooks.git
 DEPLOYMENT_TERRAFORM: https://github.com/poanetwork/deployment-terraform.git
 DEPLOYMENT_PLAYBOOKS_BRANCH: master
-DEPLOYMENT_TERRAFORM_BRANCH: master
+DEPLOYMENT_TERRAFORM_BRANCH: "1.0"
 POA_CONSENSUS_CONTRACTS: https://github.com/poanetwork/poa-network-consensus-contracts.git
 terraform_version: 0.11.7
 node_version: 8


### PR DESCRIPTION
Due to sokol hard fork on 19 of Sep, new version of poa-network-consensus-contracts was deployed, which includes a different ceremony.

While playbooks are not updated, we should use a previous version which was stored in `1.0` branch.  