### PR TITLE
Use branch with previous version of governance

### DIFF
--- a/azure/roles/moc-preconf/defaults/main.yml
+++ b/azure/roles/moc-preconf/defaults/main.yml
@@ -4,6 +4,7 @@ DEPLOYMENT_TERRAFORM: https://github.com/poanetwork/deployment-terraform.git
 DEPLOYMENT_PLAYBOOKS_BRANCH: master
 DEPLOYMENT_TERRAFORM_BRANCH: master
 POA_CONSENSUS_CONTRACTS: https://github.com/poanetwork/poa-network-consensus-contracts.git
+POA_CONSENSUS_CONTRACTS_BRANCH: "1.0"
 terraform_version: 0.11.7
 node_version: 8
 moc_secret_length: 20

--- a/azure/roles/moc-preconf/tasks/main.yml
+++ b/azure/roles/moc-preconf/tasks/main.yml
@@ -2,33 +2,34 @@
   fail:
     msg: "You can't set initial_key_count to value more than 12"
   when: initial_key_count>12 or initial_key_count<validator_count or initial_key_convert_count<validator_count or initial_key_count<initial_key_convert_count
-  
+
 - name: Check if contracts were not already deployed
   find:
     paths: "/home/moc/poa-network-consensus-contracts/"
     patterns: "contracts.json"
   register: contracts
-  
+
 - name: Clear old MoC installation
   become: true
   file:
     state: absent
     path: "/home/moc"
   when: contracts.matched == 0
-  
+
 - name: Ensure deployment playbooks exists on local server
   local_action:
     module: git
     repo: "{{ DEPLOYMENT_PLAYBOOKS }}"
     dest: "{{ playbook_dir }}/deployment-playbooks"
-    force: true 
+    force: true
     version: "{{ DEPLOYMENT_PLAYBOOKS_BRANCH }}"
-                  
+
 - name: Ensure POA contracts exists on local server
   git:
     repo: "{{ POA_CONSENSUS_CONTRACTS }}"
     dest: "/home/{{ ansible_user }}/poa-network-consensus-contracts"
     force: yes
+    version: "{{ POA_CONSENSUS_CONTRACTS_BRANCH }}"
 
 - name: Create folder that will contain all configs for created network
   file:
@@ -37,7 +38,7 @@
 
 - name: Add solc repo
   become: yes
-  apt_repository: 
+  apt_repository:
     repo: ppa:ethereum/ethereum
 
 - name: Install the gpg key for nodejs LTS
@@ -63,25 +64,25 @@
     - "{{ ansible_python_interpreter.split('/')[-1] }}-pip"
     - nodejs
     - libssl-dev
-    
+
 - name: Install latest passlib with pip
-  pip: 
-    name: "{{ item }}"   
+  pip:
+    name: "{{ item }}"
     extra_args: --user
     executable: "{{ ansible_pip }}"
   with_items:
     - passlib
     - pyopenssl
-    
+
 - name: Config store for npm modules
   shell: "npm config set prefix /home/{{ ansible_user }}/.npm-packages"
-  
+
 - name: Install NPM packages globally
   npm:
     global: yes
     name: npm
     state: latest
-    
+
 - name: Make folder for keeping network output variables
   file:
     path: "/home/{{ ansible_user }}/{{ NETWORK_NAME }}/validator-keys"
@@ -91,23 +92,23 @@
   git:
     repo: "{{ DEPLOYMENT_TERRAFORM }}"
     dest: /home/{{ ansible_user }}/deployment-terraform
-    force: true  
+    force: true
     version: "{{ DEPLOYMENT_TERRAFORM_BRANCH }}"
 
 - name: Install reqired NPM modules (key-generator)
   npm:
-    path: /home/{{ ansible_user }}/deployment-terraform/helper-scripts/key-generator/ 
+    path: /home/{{ ansible_user }}/deployment-terraform/helper-scripts/key-generator/
 
 - name: Install reqired NPM modules (scripts)
   shell: npm install
   args:
-    chdir: /home/{{ ansible_user }}/poa-network-consensus-contracts/scripts/  
-    
+    chdir: /home/{{ ansible_user }}/poa-network-consensus-contracts/scripts/
+
 - name: Installing solc if bytecode is not generated (workaround)
   shell: npm install solc
   args:
     creates: "/home/{{ ansible_user }}/{{ NETWORK_NAME }}/bytecode"
-    chdir: /home/{{ ansible_user }}/poa-network-consensus-contracts/scripts/  
+    chdir: /home/{{ ansible_user }}/poa-network-consensus-contracts/scripts/
 
 - name: Generate certificates and secrets
   shell: "/home/{{ ansible_user }}/deployment-terraform/azure/roles/moc-preconf/files/generator.sh"
@@ -116,16 +117,16 @@
     executable: "/bin/bash"
   environment:
     ANSIBLE_USER: "{{ ansible_user }}"
-    NETWORK_NAME: "{{ NETWORK_NAME }}"  
+    NETWORK_NAME: "{{ NETWORK_NAME }}"
     SRDOMAIN: "{{ ansible_host }}"
     MOC_SECRET: "{{ moc_secret }}"
-    CERT_SECRET: "{{ cert_secret }}" 
+    CERT_SECRET: "{{ cert_secret }}"
     NETSTAT_SECRET: "{{ netstat_secret }}"
     MOC_SECRET_LENGTH: "{{ moc_secret_length }}"
     CERT_SECRET_LENGTH: "{{ cert_secret_length }}"
     NETSTAT_SECRET_LENGTH: "{{ netstat_secret_length }}"
     BOOTNODE_BALANCED_COUNT: "{{ bootnode_balanced_count }}"
-    MASTER_OF_CEREMONY: "{{ MOC_ADDRESS  }}" 
+    MASTER_OF_CEREMONY: "{{ MOC_ADDRESS  }}"
 
 - name: Set secrets
   set_fact:
@@ -140,12 +141,12 @@
     src: spec.json.j2
     dest: "/home/{{ ansible_user }}/{{ NETWORK_NAME }}/spec.json"
   when: SPEC_ADDRESS == ""
-  
+
 - name: Copy spec.json to network folder
   template:
     src: "{{ SPEC_ADDRESS }}"
     dest: "/home/{{ ansible_user }}/{{ NETWORK_NAME }}/spec.json"
   when: SPEC_ADDRESS != ""
-  
+
 - name: Restore default global store for npm modules
   shell: "npm config set prefix /usr"


### PR DESCRIPTION
Due to sokol hard fork on 19 of Sep, new version of poa-network-consensus-contracts was deployed, which includes a different ceremony.

While playbooks are not updated, we should use a previous version which was stored in 1.0 branch.