### PR TITLE
Add 0x prefix for validator keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ Most of the work is done by `ansible`, but to bring up the infrastructure, ansib
 
 Currently, only deployment to Azure is supported:
 [Azure deployment README](azure/README.md)
+

--- a/azure/roles/validator/tasks/main.yml
+++ b/azure/roles/validator/tasks/main.yml
@@ -27,7 +27,7 @@
   vars:
     username: "validator"
     GENESIS_NETWORK_NAME: "{{ NETWORK_NAME }}"
-    MINING_ADDRESS: "{{ addresses.stdout }}"
+    MINING_ADDRESS: "0x{{ addresses.stdout }}"
     MINING_KEYPASS: "{{ lookup ('file', keys.stdout) }}"
     MINING_KEYFILE: "{{ lookup ('file', keyfiles.stdout) }}"
 


### PR DESCRIPTION
For convenience, add `0x` prefix for `MINING_ADDRESS` of validators nodes.

`MOC_ADDRESS` already has this prefix and though parity accepts both forms (with and without `0x`), it would be better to have a common format.